### PR TITLE
Date and Number Fields Should Be Text Fields

### DIFF
--- a/source/Willow/DateFieldWebView.class.st
+++ b/source/Willow/DateFieldWebView.class.st
@@ -16,7 +16,7 @@ DateFieldWebView class >> applying: aComponentCommand [
 { #category : #'instance creation' }
 DateFieldWebView class >> applying: aComponentCommand transformingWith: aTextCodec [
 
-	^ (self singleLineTriggeringOnChangeApplying: [ :field | field beDateInput + aComponentCommand ] asWebComponentCommand) 
+	^ (self singleLineTriggeringOnChangeApplying: [ :field | aComponentCommand ] asWebComponentCommand) 
 			initializeTransformingWith: aTextCodec
 ]
 

--- a/source/Willow/DateFieldWebView.class.st
+++ b/source/Willow/DateFieldWebView.class.st
@@ -4,10 +4,6 @@ I represent a TextField containing dates.
 Class {
 	#name : #DateFieldWebView,
 	#superclass : #FieldWebView,
-	#instVars : [
-		'textField',
-		'textCodec'
-	],
 	#category : #'Willow-WebViews'
 }
 
@@ -20,7 +16,8 @@ DateFieldWebView class >> applying: aComponentCommand [
 { #category : #'instance creation' }
 DateFieldWebView class >> applying: aComponentCommand transformingWith: aTextCodec [
 
-	^ self new initializeApplying: [ :field | field beDateInput + aComponentCommand ] asWebComponentCommand transformingWith: aTextCodec
+	^ (self singleLineTriggeringOnChangeApplying: [ :field | field beDateInput + aComponentCommand ] asWebComponentCommand) 
+			initializeTransformingWith: aTextCodec
 ]
 
 { #category : #'Date-Container-API' }
@@ -33,23 +30,4 @@ DateFieldWebView >> changeDateTo: aDate [
 DateFieldWebView >> date [
 
 	^ self model
-]
-
-{ #category : #initialization }
-DateFieldWebView >> initializeApplying: aComponentCommand transformingWith: aTextCodec [
-
-	textField := TextFieldWebView singleLineTriggeringOnChangeApplying: aComponentCommand.
-	textCodec := aTextCodec
-]
-
-{ #category : #'private - Accessing' }
-DateFieldWebView >> textCodec [
-
-	^ textCodec
-]
-
-{ #category : #'private - Accessing' }
-DateFieldWebView >> textField [
-
-	^ textField
 ]

--- a/source/Willow/FieldWebView.class.st
+++ b/source/Willow/FieldWebView.class.st
@@ -3,54 +3,33 @@ I 'm an abstract class representing non textual HTML5 inputs.
 "
 Class {
 	#name : #FieldWebView,
-	#superclass : #WAPainter,
+	#superclass : #TextFieldWebView,
+	#instVars : [
+		'textCodec'
+	],
 	#category : #'Willow-WebViews'
 }
 
 { #category : #'Container-API' }
 FieldWebView >> changeModelTo: aModel [
 
-	^ self textField changeContentsTo: (self textCodec encode: aModel)
+	^ self changeContentsTo: (self textCodec encode: aModel)
 ]
 
-{ #category : #configuring }
-FieldWebView >> identifyIn: aCanvas [
+{ #category : #initialization }
+FieldWebView >> initializeTransformingWith: aTextCodec [
 
-	^ self textField identifyIn: aCanvas
+	textCodec := aTextCodec
 ]
 
 { #category : #'Container-API' }
 FieldWebView >> model [
 
-	^ self textCodec decode: self textField contents
-]
-
-{ #category : #'Container-API' }
-FieldWebView >> notifyChangesTo: aSupervisor [
-
-	^ self textField notifyChangesTo: aSupervisor
-]
-
-{ #category : #configuring }
-FieldWebView >> onTrigger [
-
-	^ self textField onTrigger
-]
-
-{ #category : #rendering }
-FieldWebView >> renderContentOn: aCanvas [
-
-	aCanvas render: self textField
+	^ self textCodec decode: self contents
 ]
 
 { #category : #'private - Accessing' }
 FieldWebView >> textCodec [
 
-	^ self subclassResponsibility
-]
-
-{ #category : #'private - Accessing' }
-FieldWebView >> textField [
-
-	^ self subclassResponsibility
+	^ textCodec
 ]

--- a/source/Willow/Html5ComponentSupplier.class.st
+++ b/source/Willow/Html5ComponentSupplier.class.st
@@ -47,7 +47,7 @@ Html5ComponentSupplier >> checkboxUnlabeledOnModel: anObjectToUseWhenOn offModel
 { #category : #Supplying }
 Html5ComponentSupplier >> dateFieldApplying: aComponentCommand [
 
-	^ DateFieldWebView applying: aComponentCommand
+	^ DateFieldWebView applying: [ :field | field beDateInput + aComponentCommand ]
 ]
 
 { #category : #Supplying }

--- a/source/Willow/NumberFieldWebView.class.st
+++ b/source/Willow/NumberFieldWebView.class.st
@@ -4,17 +4,13 @@ I represent a TextField containing numbers.
 Class {
 	#name : #NumberFieldWebView,
 	#superclass : #FieldWebView,
-	#instVars : [
-		'textField',
-		'textCodec'
-	],
 	#category : #'Willow-WebViews'
 }
 
 { #category : #'instance creation' }
 NumberFieldWebView class >> applying: aComponentCommand transformingWith: aTextCodec [
 
-	^ self new initializeApplying: [ :field | field beNumberInput + aComponentCommand ] asWebComponentCommand transformingWith: aTextCodec
+	^ (self singleLineTriggeringOnChangeApplying: [ :field | field beNumberInput + aComponentCommand ] asWebComponentCommand) initializeTransformingWith: aTextCodec
 ]
 
 { #category : #'number-container-API' }
@@ -23,27 +19,8 @@ NumberFieldWebView >> changeNumberTo: aNumber [
 	self changeModelTo: aNumber
 ]
 
-{ #category : #initialization }
-NumberFieldWebView >> initializeApplying: aComponentCommand transformingWith: aTextCodec [
-
-	textField := TextFieldWebView singleLineTriggeringOnChangeApplying: aComponentCommand.
-	textCodec := aTextCodec
-]
-
 { #category : #'number-container-API' }
 NumberFieldWebView >> number [
 
 	^ self model
-]
-
-{ #category : #'private - Accessing' }
-NumberFieldWebView >> textCodec [
-
-	^ textCodec
-]
-
-{ #category : #'private - Accessing' }
-NumberFieldWebView >> textField [
-
-	^ textField
 ]


### PR DESCRIPTION
The failure to treat them uniformly:
1. Created a lot of unneeded duplication as much of the code was simply delegating.
2. Made working with the specialized variants difficult. For example, DNU `#identifier` when used in an expression like: `response onReturn setValueTo: aDate mmddyyyy thenTriggerChangeOf: self myDateField`