### PR TITLE
Automatically identify target component when using `setValueTo:thenTr…

### DIFF
--- a/source/Willow-Core/ComponentValueSettingCommand.class.st
+++ b/source/Willow-Core/ComponentValueSettingCommand.class.st
@@ -27,7 +27,21 @@ ComponentValueSettingCommand class >> obtainingIdentifierFrom: aValueProvider va
 { #category : #'instance creation' }
 ComponentValueSettingCommand class >> triggeringChangesObtainingIdentifierFrom: anIdentifierProvider valueFrom: aValueProvider [
 
-	^ self obtainingIdentifierFrom: aValueProvider valueFrom: anIdentifierProvider triggeringAction: [ :jQueryInstance | jQueryInstance trigger: 'change' ]
+	^ self
+		obtainingIdentifierFrom: aValueProvider
+		valueFrom: anIdentifierProvider
+		triggeringAction: [ :jQueryInstance | jQueryInstance trigger: 'change' ]
+]
+
+{ #category : #'instance creation' }
+ComponentValueSettingCommand class >> triggeringChangesOn: anIdentifiableView withValueFrom: aValueProvider [
+
+	^ self
+		triggeringChangesObtainingIdentifierFrom: [ :canvas | 
+			anIdentifiableView identifyIn: canvas.
+			anIdentifiableView identifier
+			]
+		valueFrom: aValueProvider
 ]
 
 { #category : #accessing }
@@ -51,9 +65,10 @@ ComponentValueSettingCommand >> modelLoadingActions [
 		with: [ :aScript :aCanvas | 
 			| jQueryInstance |
 
-			jQueryInstance := aScript << (aCanvas jQuery id: identifierProvider value).
+			jQueryInstance := aScript << ( aCanvas jQuery id: ( identifierProvider cull: aCanvas ) ).
 			jQueryInstance value: valueProvider value.
-			triggeringAction cull: jQueryInstance ]
+			triggeringAction cull: jQueryInstance
+			]
 ]
 
 { #category : #accessing }

--- a/source/Willow-Core/WebInteractionInterpreter.class.st
+++ b/source/Willow-Core/WebInteractionInterpreter.class.st
@@ -270,10 +270,7 @@ WebInteractionInterpreter >> serializeWithHiddenInputs [
 WebInteractionInterpreter >> setValueTo: aValueProvider thenTriggerChangeOf: anIdentifiedView [
 
 	interaction
-		onTriggerExecute:
-			( ComponentValueSettingCommand
-				triggeringChangesObtainingIdentifierFrom: [ anIdentifiedView identifier ]
-				valueFrom: aValueProvider )
+		onTriggerExecute: ( ComponentValueSettingCommand triggeringChangesOn: anIdentifiedView withValueFrom: aValueProvider )
 ]
 
 { #category : #'Configuring - DOM' }

--- a/source/Willow-Tests/ComponentValueSettingCommandTest.class.st
+++ b/source/Willow-Tests/ComponentValueSettingCommandTest.class.st
@@ -43,6 +43,29 @@ ComponentValueSettingCommandTest >> testModelLoadingActions [
 ]
 
 { #category : #'tests-accessing' }
+ComponentValueSettingCommandTest >> testModelLoadingActionsWithoutSettingPreviouslyTheId [
+
+	| html |
+
+	html := self
+		renderUsing: [ :canvas | 
+			| script input |
+
+			script := canvas javascript.
+			input := canvas textInput.
+
+			( ComponentValueSettingCommand triggeringChangesOn: input withValueFrom: [ '15' ] )
+				modelLoadingActions do: [ :action | action value: script value: canvas ].
+			input script: ( canvas jQuery this onClick: script )
+			].
+
+	self
+		assert: html
+		equals:
+			'<input id="id1" type="text"/><script type="text/javascript">$("#id1").click(function(){$("#id1").val("15").trigger("change")});</script>'
+]
+
+{ #category : #'tests-accessing' }
 ComponentValueSettingCommandTest >> testModelLoadingActionsWithoutTriggering [
 
 	| html |


### PR DESCRIPTION
…iggerChangeOf:` affordance.

Fixes #165