### PR TITLE
Added time field support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,18 +7,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        smalltalk: [ Pharo64-8.0, Pharo64-7.0, Pharo32-7.0, Pharo32-6.1 ]
+        smalltalk: [ Pharo64-8.0, Pharo64-7.0, Pharo32-7.0 ]
     name: ${{ matrix.smalltalk }}
     steps:
       - uses: actions/checkout@v2
-      - uses: ba-st-actions/setup-smalltalkCI@v1.0.0
+      - uses: hpi-swa/setup-smalltalkCI@v1
         with:
           smalltalk-version: ${{ matrix.smalltalk }}
-      - run: smalltalkci -s ${{ matrix.smalltalk }}
+      - name: Load Image and Run Tests
+        run: smalltalkci -s ${{ matrix.smalltalk }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         timeout-minutes: 15
-      - run: echo "::set-env name=SCI_COVERAGE_FILE_LOCATION::${HOME}/.smalltalkCI/_builds/coveralls_results.json"
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.6
+        uses: codecov/codecov-action@v1
         with:
+          name: ${{matrix.os}}-${{matrix.smalltalk}}
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ${{ env.SCI_COVERAGE_FILE_LOCATION }}

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Notify about a new release
-      uses: ba-st-actions/email-release-notification@v3.1.1
+      uses: ba-st-actions/email-release-notification@v3.1.2
       env:
         SENDGRID_API_TOKEN: ${{ secrets.SENDGRID_API_TOKEN }}
         RECIPIENTS_URL: ${{ secrets.RECIPIENTS_URL }}

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -9,7 +9,8 @@ SmalltalkCISpec {
   ],
   #testing : {
     #coverage : {
-       #packages : [ 'Willow*' ]
+      #packages : [ 'Willow*' ],
+      #format: #lcov
     }
   }
 }

--- a/source/Willow-Core/DateFieldWebView.class.st
+++ b/source/Willow-Core/DateFieldWebView.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : #DateFieldWebView,
 	#superclass : #FieldWebView,
 	#instVars : [
-		'textField',
 		'textCodec'
 	],
 	#category : #'Willow-Core-WebViews'

--- a/source/Willow-Core/FrontendComponentSupplier.class.st
+++ b/source/Willow-Core/FrontendComponentSupplier.class.st
@@ -116,6 +116,12 @@ FrontendComponentSupplier >> tableBuilder [
 ]
 
 { #category : #Supplying }
+FrontendComponentSupplier >> timeFieldApplying: aComponentCommand [
+
+	self subclassResponsibility
+]
+
+{ #category : #Supplying }
 FrontendComponentSupplier >> unorderedListApplying: aCommandToList listing: aCollection applyingToEach: aCommandToItem [
 
 	^ self subclassResponsibility 

--- a/source/Willow-Core/Html5ComponentSupplier.class.st
+++ b/source/Willow-Core/Html5ComponentSupplier.class.st
@@ -127,6 +127,12 @@ Html5ComponentSupplier >> tableBuilder [
 ]
 
 { #category : #Supplying }
+Html5ComponentSupplier >> timeFieldApplying: aComponentCommand [
+
+	^ TimeFieldWebView applying: aComponentCommand
+]
+
+{ #category : #Supplying }
 Html5ComponentSupplier >> unorderedListApplying: aCommandToList listing: aCollection applyingToEach: aCommandToItem [
 
 	^ UnorderedListWebView applying: aCommandToList listing: aCollection applyingToEach: aCommandToItem

--- a/source/Willow-Core/ISOTimeCodec.class.st
+++ b/source/Willow-Core/ISOTimeCodec.class.st
@@ -1,0 +1,86 @@
+"
+I'm an encoder/decoder of Times
+"
+Class {
+	#name : #ISOTimeCodec,
+	#superclass : #Codec,
+	#category : #'Willow-Core-Frontend'
+}
+
+{ #category : #'private - preconditions' }
+ISOTimeCodec >> assertIsValidHour: aPotentialHour [
+
+	AssertionChecker
+		enforce: [ aPotentialHour between: 0 and: 23 ]
+		because: 'The hour must be an integer between 0 and 23'
+		raising: InstanceCreationFailed
+]
+
+{ #category : #'private - preconditions' }
+ISOTimeCodec >> assertIsValidMinute: aPotentialMinute [
+
+	AssertionChecker
+		enforce: [ aPotentialMinute between: 0 and: 59 ]
+		because: 'The minute must be an integer between 0 and 59'
+		raising: InstanceCreationFailed
+]
+
+{ #category : #'private - preconditions' }
+ISOTimeCodec >> assertIsValidSecond: aPotentialSecond [
+
+	AssertionChecker
+		enforce: [ aPotentialSecond between: 0 and: 59 ]
+		because: 'The second must be an integer between 0 and 59'
+		raising: InstanceCreationFailed
+]
+
+{ #category : #'private - preconditions' }
+ISOTimeCodec >> canCreate: anObject [
+
+	^ anObject isA: Time
+]
+
+{ #category : #'private - preconditions' }
+ISOTimeCodec >> decode: aString [
+
+	| hour minute second |
+
+	AssertionCheckerBuilder new
+		raising: InstanceCreationFailed;
+		checking: [ :asserter | 
+			asserter
+				enforce: [ aString size = 8 ]
+				because: 'Invalid time format'
+				onSuccess: [ :successAsserter | 
+					successAsserter
+						enforce: [ ( aString at: 3 ) = $: ] because: 'Invalid separator';
+						enforce: [ ( aString at: 6 ) = $: ] because: 'Invalid separator'
+					]
+			];
+		buildAndCheck.
+
+	hour := self readIntegerFrom: ( aString copyFirst: 2 ).
+	minute := self readIntegerFrom: ( aString copyFrom: 4 to: 5 ).
+	second := self readIntegerFrom: ( aString copyFrom: 7 to: 8 ).
+
+	self
+		assertIsValidHour: hour;
+		assertIsValidMinute: minute;
+		assertIsValidSecond: second.
+
+	^ Time hour: hour minute: minute second: second
+]
+
+{ #category : #'private - preconditions' }
+ISOTimeCodec >> encode: aTime [
+
+	^ GRPrinter isoTime print: aTime
+]
+
+{ #category : #'private - parsing' }
+ISOTimeCodec >> readIntegerFrom: aString [
+
+	^ Integer
+		readFrom: aString
+		ifFail: [ :errorDescription :position | InstanceCreationFailed signal: errorDescription ]
+]

--- a/source/Willow-Core/InputModeCommand.class.st
+++ b/source/Willow-Core/InputModeCommand.class.st
@@ -40,6 +40,12 @@ InputModeCommand class >> asText [
 	^ self settingTypeTo: 'text'
 ]
 
+{ #category : #'Instance Creation' }
+InputModeCommand class >> asTime [
+
+	^ self settingTypeTo: 'time'
+]
+
 { #category : #'private-Instance Creation' }
 InputModeCommand class >> settingTypeTo: aType [
 	

--- a/source/Willow-Core/TimeFieldWebView.class.st
+++ b/source/Willow-Core/TimeFieldWebView.class.st
@@ -1,0 +1,57 @@
+"
+I represent a TextField containing times.
+"
+Class {
+	#name : #TimeFieldWebView,
+	#superclass : #FieldWebView,
+	#instVars : [
+		'textCodec'
+	],
+	#category : #'Willow-Core-WebViews'
+}
+
+{ #category : #'instance creation' }
+TimeFieldWebView class >> applying: aComponentCommand [
+
+	^ self applying: aComponentCommand transformingWith: ISOTimeCodec new
+]
+
+{ #category : #'instance creation' }
+TimeFieldWebView class >> applying: aComponentCommand transformingWith: aTextCodec [
+
+	^ ( self
+		forComponentBuiltUsing: [ :canvas | canvas textInput ]
+		withInteractionDefinedBy: self changeInterpreter
+		applying: [ :field | field beTimeInput + aComponentCommand ] asWebComponentCommand )
+		initializeTransformingWith: aTextCodec
+]
+
+{ #category : #'Time-Container-API' }
+TimeFieldWebView >> changeTimeTo: aTime [
+
+	self changeModelTo: aTime
+]
+
+{ #category : #'private - Accessing' }
+TimeFieldWebView >> identifierPrefix [
+
+	^ 'time-field'
+]
+
+{ #category : #initialization }
+TimeFieldWebView >> initializeTransformingWith: aTextCodec [
+
+	textCodec := aTextCodec
+]
+
+{ #category : #'private - Accessing' }
+TimeFieldWebView >> textCodec [
+
+	^ textCodec
+]
+
+{ #category : #'Time-Container-API' }
+TimeFieldWebView >> time [
+
+	^ self model
+]

--- a/source/Willow-Core/WebComponentCommandBuilder.class.st
+++ b/source/Willow-Core/WebComponentCommandBuilder.class.st
@@ -77,6 +77,12 @@ WebComponentCommandBuilder >> beTextInput [
 ]
 
 { #category : #Building }
+WebComponentCommandBuilder >> beTimeInput [
+
+	^ InputModeCommand asTime
+]
+
+{ #category : #Building }
 WebComponentCommandBuilder >> boundBetween: aLowerBound and: anUpperBound [
 
 	^ ComponentBoundaryCommand between: aLowerBound and: anUpperBound

--- a/source/Willow-Tests/Html5ComponentSupplierTest.class.st
+++ b/source/Willow-Tests/Html5ComponentSupplierTest.class.st
@@ -261,6 +261,14 @@ Html5ComponentSupplierTest >> testTableBuilderWithSimpleColumns [
 ]
 
 { #category : #'tests-Supplying' }
+Html5ComponentSupplierTest >> testTimeFieldApplying [
+
+	self
+		assertRenderingOf: [ :supplier | supplier timeFieldApplying: [ :field |  ] ]
+		equals: '<input value="" name="1" type="time"/>'
+]
+
+{ #category : #'tests-Supplying' }
 Html5ComponentSupplierTest >> testUnorderedListApplyingListingApplyingToEach [
 
 	self

--- a/source/Willow-Tests/ISODateCodecTest.class.st
+++ b/source/Willow-Tests/ISODateCodecTest.class.st
@@ -28,7 +28,8 @@ ISODateCodecTest >> testCantDecodeDate [
 		should: [ ISODateCodec new decode: '010-13-11' ] raise: InstanceCreationFailed;
 		should: [ ISODateCodec new decode: '2010-13-11' ] raise: InstanceCreationFailed;
 		should: [ ISODateCodec new decode: '2010-1-11' ] raise: InstanceCreationFailed;
-		should: [ ISODateCodec new decode: '2010-13-1' ] raise: InstanceCreationFailed
+		should: [ ISODateCodec new decode: '2010-13-1' ] raise: InstanceCreationFailed;
+		should: [ ISODateCodec new decode: '2020/12/11' ] raise: InstanceCreationFailed
 ]
 
 { #category : #tests }

--- a/source/Willow-Tests/ISOTimeCodecTest.class.st
+++ b/source/Willow-Tests/ISOTimeCodecTest.class.st
@@ -1,0 +1,54 @@
+"
+A ISOTimeCodecTest is a test class for testing the behavior of ISOTimeCodec
+"
+Class {
+	#name : #ISOTimeCodecTest,
+	#superclass : #TestCase,
+	#category : #'Willow-Tests-Frontend'
+}
+
+{ #category : #tests }
+ISOTimeCodecTest >> testCanCreate [
+
+	self
+		assert: ( ISOTimeCodec new canCreate: Time now );
+		deny: ( ISOTimeCodec new canCreate: Date today );
+		deny: ( ISOTimeCodec new canCreate: '11.03.55' )
+]
+
+{ #category : #tests }
+ISOTimeCodecTest >> testCantDecodeTime [
+
+	self
+		should: [ ISOTimeCodec new decode: '25:03:55' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '11:60:55' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '11:03:60' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '1:03:55' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '11:3:55' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '11:03:5' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '11:3:5' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '1:03:5' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '1:3:55' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '1:3:5' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '11 03 55' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '11.03.55' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '11,03,55' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '11:03:55 AM' ] raise: InstanceCreationFailed;
+		should: [ ISOTimeCodec new decode: '11:03:55 PM' ] raise: InstanceCreationFailed
+]
+
+{ #category : #tests }
+ISOTimeCodecTest >> testDecode [
+
+	self
+		assert: ( ISOTimeCodec new decode: '11:03:55' )
+		equals: ( Time hour: 11 minute: 03 second: 55 )
+]
+
+{ #category : #tests }
+ISOTimeCodecTest >> testEncode [
+
+	self
+		assert: ( ISOTimeCodec new encode: ( Time hour: 11 minute: 03 second: 55 ) )
+		equals: '11:03:55'
+]

--- a/source/Willow-Tests/InputModeCommandTest.class.st
+++ b/source/Willow-Tests/InputModeCommandTest.class.st
@@ -36,3 +36,13 @@ InputModeCommandTest >> testApplyPasswordInputCommand [
 
 	self assert: html equals: '<input type="password"/>'
 ]
+
+{ #category : #'tests-processing' }
+InputModeCommandTest >> testApplyTimeInputCommand [
+
+	| html |
+
+	html := self apply: InputModeCommand asTime toComponentDefinedBy: [ :canvas | canvas textInput ].
+
+	self assert: html equals: '<input type="time"/>'
+]

--- a/source/Willow-Tests/TimeFieldWebViewTest.class.st
+++ b/source/Willow-Tests/TimeFieldWebViewTest.class.st
@@ -1,0 +1,92 @@
+"
+A TimeFieldWebViewTest is a test class for testing the behavior of TimeFieldWebView
+"
+Class {
+	#name : #TimeFieldWebViewTest,
+	#superclass : #BWRenderingTest,
+	#instVars : [
+		'notificationWasReceived'
+	],
+	#category : #'Willow-Tests-WebViews'
+}
+
+{ #category : #support }
+TimeFieldWebViewTest >> changeNotifiedBy: aTextFieldWebView [ 
+	
+	notificationWasReceived := true
+]
+
+{ #category : #support }
+TimeFieldWebViewTest >> testIdentifyIn [
+
+	| timeField html |
+
+	timeField := TimeFieldWebView applying: [ :field |  ].
+
+	html := self
+		renderUsing: [ :canvas | 
+			timeField identifyIn: canvas.
+			canvas render: timeField
+			].
+
+	self assert: html equals: '<input value="" name="2" id="time-field-id1" type="time"/>'
+]
+
+{ #category : #support }
+TimeFieldWebViewTest >> testNotifyChangesTo [
+
+	| timeField |
+
+	timeField := TimeFieldWebView applying: [ :field |  ].
+
+	timeField notifyChangesTo: self.
+	notificationWasReceived := false.
+	timeField changeTimeTo: Time now.
+	self assert: notificationWasReceived
+]
+
+{ #category : #support }
+TimeFieldWebViewTest >> testOnTrigger [
+
+	| timeField html |
+
+	timeField := TimeFieldWebView applying: [ :field |  ].
+
+	timeField onTrigger disable.
+	html := self render: timeField.
+
+	self
+		assert: html
+		equals:
+			'<input value="" name="1" type="time" id="input-id2"/><script type="text/javascript">$("#input-id2").change(function(event){$(this).prop("disabled",true)});</script>'
+]
+
+{ #category : #support }
+TimeFieldWebViewTest >> testRenderContentOn [
+
+	| timeField html |
+
+	timeField := TimeFieldWebView applying: [ :field |  ].
+
+	html := self render: timeField.
+
+	self assert: html equals: '<input value="" name="1" type="time"/>'
+]
+
+{ #category : #support }
+TimeFieldWebViewTest >> testTime [
+
+	| timeField html currentTime |
+
+	timeField := TimeFieldWebView applying: [ :field |  ].
+
+	self should: [ timeField time ] raise: InstanceCreationFailed.
+
+	currentTime := Time hour: 11 minute: 28 second: 55.
+	timeField changeTimeTo: currentTime.
+
+	self assert: timeField time equals: currentTime.
+	html := self render: timeField.
+
+	self assert: html equals: '<input value="11:28:55" name="1" type="time"/>'
+]

--- a/source/Willow-Tests/WebComponentCommandBuilderTest.class.st
+++ b/source/Willow-Tests/WebComponentCommandBuilderTest.class.st
@@ -183,25 +183,35 @@ WebComponentCommandBuilderTest >> testInputModeCommands [
 
 	| html |
 
-	html := self apply: self commandBuilder beDateInput toComponentDefinedBy: [ :canvas | canvas textInput ].
+	html := self
+		apply: self commandBuilder beDateInput
+		toComponentDefinedBy: [ :canvas | canvas textInput ].
 
-	self assert: html equals: (self renderUsing: [ :canvas | canvas dateInput5 ]).
+	self assert: html equals: ( self renderUsing: [ :canvas | canvas dateInput5 ] ).
 
-	html := self apply: self commandBuilder beNumberInput toComponentDefinedBy: [ :canvas | canvas textInput ].
+	html := self
+		apply: self commandBuilder beNumberInput
+		toComponentDefinedBy: [ :canvas | canvas textInput ].
 
-	self assert: html equals: (self renderUsing: [ :canvas | canvas numberInput ]).
+	self assert: html equals: ( self renderUsing: [ :canvas | canvas numberInput ] ).
 
-	html := self apply: self commandBuilder bePasswordInput toComponentDefinedBy: [ :canvas | canvas textInput ].
+	html := self
+		apply: self commandBuilder bePasswordInput
+		toComponentDefinedBy: [ :canvas | canvas textInput ].
 
 	self assert: html equals: '<input type="password"/>'.
 
-	html := self apply: self commandBuilder beEmailInput toComponentDefinedBy: [ :canvas | canvas textInput ].
+	html := self
+		apply: self commandBuilder beEmailInput
+		toComponentDefinedBy: [ :canvas | canvas textInput ].
 
 	self assert: html equals: '<input type="email"/>'.
 
-	html := self apply: self commandBuilder beTextInput toComponentDefinedBy: [ :canvas | canvas textInput type: 'date' ].
+	html := self
+		apply: self commandBuilder beTimeInput
+		toComponentDefinedBy: [ :canvas | canvas textInput ].
 
-	self assert: html equals: '<input type="text"/>'
+	self assert: html equals: '<input type="time"/>'
 ]
 
 { #category : #tests }


### PR DESCRIPTION
closes #187 .
Added time field support. In order to do this, I created a DateFieldWebView class, sub classifying FieldWebView. Also, its corresponding Codec (ISOTimeCodec). Now, WebComponentCommandBuilder understands a new message: beTimeInput, collaborating with InputModeCommand for setting the time type.